### PR TITLE
Felfedező javítás

### DIFF
--- a/backend/UnderSea.Api/Controllers/BattleController.cs
+++ b/backend/UnderSea.Api/Controllers/BattleController.cs
@@ -48,6 +48,12 @@ namespace UnderSea.Api.Controllers
             return Ok(userunits);
         }
 
+        [HttpGet("spies")]
+        public async Task<ActionResult<BattleUnitDto>> GetSpies()
+        {
+            return Ok(await service.GetSpies());
+        }
+
         [HttpPost("attack")]
         public async Task<ActionResult> Attack([FromBody] SendAttackDto sendAttack)
         {

--- a/backend/UnderSea.Bll/Services/BattleService.cs
+++ b/backend/UnderSea.Bll/Services/BattleService.cs
@@ -205,8 +205,8 @@ namespace UnderSea.Bll.Services
                 .Include(c => c.CountryUnits)
                 .FirstOrDefaultAsync();
 
-            var spyUnit = await _context.Units.FirstOrDefaultAsync(c => c.Name == UnitConstants.Felfedezo);
-            var spies = country.CountryUnits.Where(cu => cu.UnitId == spyUnit.Id).FirstOrDefault();
+            var spyUnit = await _context.Units.SingleOrDefaultAsync(c => c.Name == UnitConstants.Felfedezo);
+            var spies = country.CountryUnits.SingleOrDefault(cu => cu.UnitId == spyUnit.Id);
 
             return new BattleUnitDto
             {

--- a/backend/UnderSea.Bll/Services/CountryService.cs
+++ b/backend/UnderSea.Bll/Services/CountryService.cs
@@ -73,14 +73,14 @@ namespace UnderSea.Bll.Services
                 CurrentPearlProduction = (int)(country.Production.BasePearlProduction * country.Production.PearlProductionMultiplier),
                 Buildings = buildings.Select(building =>
                 {
-                    var buildingCount = country.CountryBuildings.Where(cb => cb.BuildingId == building.Id).FirstOrDefault();
-                    var activeBuildingCount = country.ActiveConstructions.Where(ac => ac.BuildingId == building.Id).Count();
+                    var countryBuilding = country.CountryBuildings.SingleOrDefault(cb => cb.BuildingId == building.Id);
+                    var activeBuildingCount = country.ActiveConstructions.Count(ac => ac.BuildingId == building.Id);
 
                     return new BuildingInfoDto
                     {
                         Id = building.Id,
                         Name = building.Name,
-                        BuildingsCount = buildingCount == null ? 0 : buildingCount.Count,
+                        BuildingsCount = countryBuilding == null ? 0 : countryBuilding.Count,
                         ActiveConstructionCount = activeBuildingCount,
                         IconImageUrl = building.IconImageUrl
                     };

--- a/backend/UnderSea.Bll/Services/CountryService.cs
+++ b/backend/UnderSea.Bll/Services/CountryService.cs
@@ -73,12 +73,15 @@ namespace UnderSea.Bll.Services
                 CurrentPearlProduction = (int)(country.Production.BasePearlProduction * country.Production.PearlProductionMultiplier),
                 Buildings = buildings.Select(building =>
                 {
+                    var buildingCount = country.CountryBuildings.Where(cb => cb.BuildingId == building.Id).FirstOrDefault();
+                    var activeBuildingCount = country.ActiveConstructions.Where(ac => ac.BuildingId == building.Id).Count();
+
                     return new BuildingInfoDto
                     {
                         Id = building.Id,
                         Name = building.Name,
-                        BuildingsCount = country.CountryBuildings.Where(cb => cb.BuildingId == building.Id).Count(),
-                        ActiveConstructionCount = country.ActiveConstructions.Where(ac => ac.BuildingId == building.Id).Count(),
+                        BuildingsCount = buildingCount == null ? 0 : buildingCount.Count,
+                        ActiveConstructionCount = activeBuildingCount,
                         IconImageUrl = building.IconImageUrl
                     };
                 })

--- a/backend/UnderSea.Bll/Services/Interfaces/IBattleService.cs
+++ b/backend/UnderSea.Bll/Services/Interfaces/IBattleService.cs
@@ -16,6 +16,7 @@ namespace UnderSea.Bll.Services.Interfaces
         Task<PagedResult<AttackableUserDto>> GetAttackableUsersAsync(PaginationData data, string name);
         Task<IEnumerable<BattleUnitDto>> GetUserUnitsAsync();
         Task<IEnumerable<BattleUnitDto>> GetUserAllUnitsAsync();
+        Task<BattleUnitDto> GetSpies();
         Task<PagedResult<LoggedAttackDto>> GetLoggedAttacksAsync(PaginationData data);
         Task<PagedResult<SpyReportDto>> GetLoggedSpyReportsAsync(PaginationData data);
         Task<IEnumerable<UnitDto>> GetAllUnitsAsync();

--- a/frontend/angular/under-sea/src/app/services/generated-code/generated-api-code.ts
+++ b/frontend/angular/under-sea/src/app/services/generated-code/generated-api-code.ts
@@ -176,6 +176,53 @@ export class BattleService {
         return _observableOf<BattleUnitDto[]>(<any>null);
     }
 
+    spies(): Observable<BattleUnitDto> {
+        let url_ = this.baseUrl + "/api/Battle/spies";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_ : any = {
+            observe: "response",
+            responseType: "blob",
+            headers: new HttpHeaders({
+                "Accept": "application/json"
+            })
+        };
+
+        return this.http.request("get", url_, options_).pipe(_observableMergeMap((response_ : any) => {
+            return this.processSpies(response_);
+        })).pipe(_observableCatch((response_: any) => {
+            if (response_ instanceof HttpResponseBase) {
+                try {
+                    return this.processSpies(<any>response_);
+                } catch (e) {
+                    return <Observable<BattleUnitDto>><any>_observableThrow(e);
+                }
+            } else
+                return <Observable<BattleUnitDto>><any>_observableThrow(response_);
+        }));
+    }
+
+    protected processSpies(response: HttpResponseBase): Observable<BattleUnitDto> {
+        const status = response.status;
+        const responseBlob =
+            response instanceof HttpResponse ? response.body :
+            (<any>response).error instanceof Blob ? (<any>response).error : undefined;
+
+        let _headers: any = {}; if (response.headers) { for (let key of response.headers.keys()) { _headers[key] = response.headers.get(key); }}
+        if (status === 200) {
+            return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
+            let result200: any = null;
+            result200 = _responseText === "" ? null : <BattleUnitDto>JSON.parse(_responseText, this.jsonParseReviver);
+            return _observableOf(result200);
+            }));
+        } else if (status !== 200 && status !== 204) {
+            return blobToText(responseBlob).pipe(_observableMergeMap(_responseText => {
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+            }));
+        }
+        return _observableOf<BattleUnitDto>(<any>null);
+    }
+
     attack(sendAttack: SendAttackDto): Observable<FileResponse | null> {
         let url_ = this.baseUrl + "/api/Battle/attack";
         url_ = url_.replace(/[?&]$/, "");


### PR DESCRIPTION
Beszéltük a srácokkal, hogy a kémeket külön részre tennék a UI-on, emiatt átalakítottam az api-t pár ponton. 
Megbeszéltük, hogy a támadások mellé nem lehet kémet küldeni (nincs értelme), így innentől kezdve az api hibát dob ilyenkor. Ebből következik, hogy az egységek lekérésénél is kikerült a kém (kivétel. infobar), így most egy másik endpointról lehet lekérni a darabszámot, ha kémet küldenénk valahova.